### PR TITLE
    Require cors-support on api-mock.cofee

### DIFF
--- a/src/api-mock.coffee
+++ b/src/api-mock.coffee
@@ -5,6 +5,7 @@ express = require 'express'
 
 walker = require './walker'
 SslSupport = require './ssl-support'
+CorsSupport = require './cors-support'
 
 class ApiMock
   constructor: (config) ->


### PR DESCRIPTION
``````
Fixes the following error:

  ```
ReferenceError: CorsSupport is not defined
ReferenceError: CorsSupport is not defined
    at new ApiMock (/Users/lucas.caro/checkout/apiv2blueprint/node_modules/api-mock/lib/api-mock.js:42:25)
    at Object.<anonymous> (/Users/lucas.caro/checkout/apiv2blueprint/node_modules/api-mock/bin/api-mock:85:13)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:902:3
```
``````
