### PR TITLE
added ability to select which request gets returned to the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,14 @@ or
       --version           Show version number.
 
 
+## Prefer headers
+
+You can set both `prefer` and `prefer-request` headers to control which example gets returned to the
+client. 
+
+```
+Prefer: 400
+Prefer-Request: valid
+```
+
+Will return a response with the name `400` from a request named `valid`

--- a/src/example-to-http-payload-pair.coffee
+++ b/src/example-to-http-payload-pair.coffee
@@ -27,6 +27,7 @@ exampleToHttpPayloadPair = (example, inheritingHeaders = {}) ->
         body: ""
         headers: {}
 
+    request['name'] = selectedRequest['name']
     request['body'] = selectedRequest['body']
     request['headers'] = inheritHeaders selectedRequest['headers'], inheritingHeaders
 


### PR DESCRIPTION
API Blueprint allows for multiple request/response pairs, such as code below:

```
+ Request valid
    + Headers

            Accept: application/json
            Version: v1
    + Body

            {
                "resetCode": "dc6dbb7276",
                "password": "mynewpass",
                "passwordConfirm": "mynewpass",
                "ipAddress": "127.0.0.1",
                "userAgent": "Google Chrome"
            }

+ Response 200
        [User][]

+ Response 404 (application/json)
    + Body

            {
                "error": true,
                "code": "invalid_reset_code",
                "message": "The reset request was not found or expired",
                "statusCode": 404
            }

+ Request invalid
    + Headers

            Accept: application/json
            Version: v1
    + Body

            {
                "resetCode": "dc6dbb7276",
                "password": "mynewpas",
                "passwordConfirm": "mynewpass",
                "ipAddress": "127.0.0.1",
                "userAgent": "Google Chrome"
            }

+ Response 400 (application/json)
    + Body

            {
                "error": true,
                "code": "password_mismatch",
                "message": "The passwords did not match",
                "statusCode": 400
            }
```

With the current `api-mock`, it was impossible to get it to return the `200` or `404` responses. 

This PR fixes it.  We tested it with our api docs and it did not regress anywhere. 

I also added a bit of documentation to the readme on how to use `prefer` and `prefer-request` header. 
