### PR TITLE
Remove CORS logging

### DIFF
--- a/src/cors-support.coffee
+++ b/src/cors-support.coffee
@@ -21,9 +21,4 @@ class CorsSupport
         else
           next()
 
-    winston.info "Enabled Cross-Origin-Resource-Sharing (CORS)"
-    winston.info "\tAllow-Origin: #{options.origin}"
-    winston.info "\tAllow-Methods: #{options.methods}"
-    winston.info "\tAllow-Headers: #{options.headers}"
-
 module.exports = CorsSupport


### PR DESCRIPTION
This doesn’t really serve any useful purpose and is quite annoying when api-mock is used as a library instead of via the CLI.
