### PR TITLE
Dynamically allow all CORS requests by echoing back requested headers

### DIFF
--- a/src/cors-support.coffee
+++ b/src/cors-support.coffee
@@ -3,18 +3,13 @@ winston = require 'winston'
 class CorsSupport
   constructor: (app) ->
 
-    options =
-      origin: '*'
-      methods: 'GET, PUT, POST, PATCH, DELETE, TRACE, OPTIONS'
-      headers: 'Origin, X-Requested-With, Content-Type, Accept, Authorization, Referer, Prefer'
-
     app.all '*', (req, res, next) ->
       unless req.get('Origin')
         next()
       else
-        res.set 'Access-Control-Allow-Origin', options.origin
-        res.set 'Access-Control-Allow-Methods', options.methods
-        res.set 'Access-Control-Allow-Headers', options.headers
+        res.set('Access-Control-Allow-Origin', "*")
+        res.set('Access-Control-Allow-Methods', req.method)
+        res.set('Access-Control-Allow-Headers', req.headers['access-control-request-headers'])
 
         if 'OPTIONS' == req.method
           res.send(200);


### PR DESCRIPTION
Instead of hard-coding a list of headers, we simply echo back the requested headers. This way, all headers are permitted. Same thing with the request method.
