### PR TITLE
Feature - conditional body mapping & API polymorphism

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-mock",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A mock server generated from your API Blueprint.",
   "author": "Evan Cordell <cordell.evan@gmail.com>",
   "main": "lib/api-mock.js",
@@ -13,9 +13,10 @@
     "prepublish": "scripts/prepublish"
   },
   "dependencies": {
-    "protagonist": "~0.17.1",
-    "optimist": "~0.6.0",
+    "body-parser": "^1.12.0",
     "express": "~3.4.7",
+    "optimist": "~0.6.0",
+    "protagonist": "~0.17.1",
     "uri-template": "~0.4.1",
     "winston": "~0.7.2"
   },

--- a/src/api-mock.coffee
+++ b/src/api-mock.coffee
@@ -18,6 +18,8 @@ class ApiMock
     @configuration = config
     @app = express()
 
+    @app.use(require("body-parser").text())
+
     if @configuration.options['ssl-enable']
       sslSupport = new SslSupport(
         @app,

--- a/src/build-express-handler.coffee
+++ b/src/build-express-handler.coffee
@@ -1,0 +1,74 @@
+winston = require 'winston'
+
+comparePayloads = (expected, actual) ->
+  if !expected
+    return true
+
+  if typeof expected == 'object'
+    if typeof actual != 'object' or actual == null
+      return false
+    for k, v of expected
+      if !actual[k] or !actual.hasOwnProperty(k)
+        return false
+
+      if !module.exports.comparePayloads(v, actual[k])
+        return false
+  else
+    if expected.toString() != actual.toString()
+      return false
+  return true
+
+respond = (requestObject, responseObject, payload) ->
+
+  respondWithPayload = (response) ->
+    for header, value of response.headers
+      responseObject.setHeader value['name'], value['value']
+    responseObject.setHeader 'Content-Length', Buffer.byteLength(response.body)
+    return responseObject.send status, response.body
+
+  for status, response of payload.responses
+    if "prefer" of requestObject.headers
+      if requestObject.headers["prefer"] != status
+        continue
+    return respondWithPayload(response)
+
+  keys = Object.keys(payload.responses)
+  winston.warn "[#{payload.path}] Preferred response #{requestObject.headers['prefer']} not found. Falling back to #{keys[0]}"
+  return respondWithPayload(payload.responses[keys[0]])
+
+matchBody = (requestObject, body, headers) ->
+  if headers["content-type"] = "application/json"
+    try
+      body = JSON.parse body
+    catch e
+      winston.warn "Could not parse body JSON"
+
+  try
+    requestPayload = requestObject.body.toString()
+    if requestPayload.length == 0 or requestObject.headers['Content-Type'] != 'application/json'
+      requestPayload = requestObject.query
+    else
+      requestPayload JSON.parse requestPayload
+
+    # Done parsing the request payload. Let's have some fun.
+    return module.exports.comparePayloads(body, requestPayload)
+  catch e
+    # Literal match on body
+    return body.toString() == requestObject.body.toString()
+
+matchHeaders = (requestObject, headers) ->
+  return comparePayloads(headers, requestObject.headers)
+
+buildExpressHandler = (payloads) ->
+  return (request, response) ->
+    for payload in payloads
+      if payload.request.body and !matchBody(request, payload.request.body, request.headers)
+        continue
+      if payload.request.headers and !matchHeaders(request, payload.request.headers)
+        continue
+      return respond(request, response, payload)
+    return respond(request, response, payloads[payloads.length -1])
+
+buildExpressHandler.comparePayloads = comparePayloads
+module.exports = buildExpressHandler
+

--- a/test/unit/build-express-handler-test.coffee
+++ b/test/unit/build-express-handler-test.coffee
@@ -1,0 +1,124 @@
+{assert} = require 'chai'
+sinon = require 'sinon'
+proxyquire = require 'proxyquire'
+
+winstonStub = require 'winston'
+
+expressHandler = proxyquire '../../src/build-express-handler', {
+  'winston': winstonStub
+}
+
+describe 'build-express-handler', () ->
+  describe 'body comparison', () ->
+    it 'should correctly match two empty strings', () ->
+      assert.isTrue expressHandler.comparePayloads(null, null)
+    it 'should correctly match two differing strings', () ->
+      assert.isFalse expressHandler.comparePayloads('foo', 'bar')
+    it 'should correctly match a null expectation with a body containing data', () ->
+      assert.isTrue expressHandler.comparePayloads(null, {"foo": "bar"})
+    it 'should identify a non-matching body', () ->
+      assert.isFalse expressHandler.comparePayloads({"foo":"4"}, {"foo":"3"})
+    it 'should be lenient on types for non-objects', () ->
+      assert.isTrue expressHandler.comparePayloads({"foo":4}, {"foo":"4"}), "Comparison works: integer type is typecasted to string"
+    it 'should correctly recurse for deep-match', () ->
+      sinon.spy expressHandler, "comparePayloads"
+      assert.isFalse expressHandler.comparePayloads({"foo":{"bar":"baz"}}, {"foo":{"barry":"baz"}}), "Comparison failed: inside key not matched"
+      assert.isTrue expressHandler.comparePayloads.calledWith({"foo":{"bar":"baz"}}, {"foo":{"barry":"baz"}}), "Initial call happened"
+      assert.isTrue expressHandler.comparePayloads.calledWith({"bar":"baz"}, {"barry":"baz"}), "Second recursion happened"
+    it 'should not match null to a valid object', () ->
+      assert.isFalse expressHandler.comparePayloads({"foo":{"bar":"baz"}}, null)
+
+  describe 'matchBody', () ->
+
+    it 'should check for payload headers before parsing json', () ->
+      body = JSON.stringify {'foo':'bar'}
+      headers = {'content-type': 'application/json'}
+      expressHandler.matchBody {'body': body, 'headers': headers}, body, headers
+      assert.isTrue expressHandler.comparePayloads.calledWith('bar', 'bar')
+
+    it 'should check the query object', () ->
+      body = JSON.stringify {'foo': 'bar'}
+      headers = {}
+      expressHandler.matchBody {'query': body, 'body': ''}, body, {}
+      assert.isTrue expressHandler.comparePayloads.calledWith(body, body)
+
+    it 'should fallback to a literal match on malformatted bodies', () ->
+      sinon.stub winstonStub, 'warn', () ->
+      body = '{"foo":bar}'
+      headers = {'content-type': 'application/json'}
+      assert.isTrue expressHandler.matchBody({'body':body, 'headers': headers}, body, headers)
+      assert.isTrue winstonStub.warn.calledTwice
+      winstonStub.warn.restore()
+
+  describe 'matcher', () ->
+    it 'should fallback to the last response if nothing matches', (done) ->
+      request = {
+        headers: {}
+        body: ""
+      }
+      payloads = [
+        {
+          request: {
+            headers: {
+              'content-type': 'application/json'
+            }
+          },
+          response: {
+            status: 200,
+            body: 'foo'
+          }
+        }
+      ]
+      o = sinon.stub(expressHandler, "respond", (o1, o2, payload) ->
+        assert.equal payload.response.status, 200
+        assert.equal payload.response.body, 'foo'
+        done()
+      );
+      s = expressHandler payloads
+      foo = {}
+      s request, foo
+      assert.isTrue o.calledOnce
+      o.restore()
+      
+    it 'should properly attempt to match a body that contains json', () ->
+      headers = {
+        "content-type": "application/json"
+      }
+      request = {
+        headers: headers
+        body: "{\"foo\":2}"
+      }
+      payloads = [
+        {
+          "request": {
+            "body": {
+              "foo": 3
+            }
+          }
+        },
+        {
+          "request": {
+            "body": {
+              "foo": 2
+            },
+            "headers": {
+              "content-type": "application/json+uml"
+            }
+          }
+        }
+        {
+          "response": {
+            "body": "foo",
+            "headers": {
+              "content-type": "text-plain"
+            }
+          }
+        }
+      ]
+      o = sinon.stub(expressHandler, "respond", () ->);
+      s = expressHandler payloads
+      foo = {}
+      s request, foo
+      assert.isTrue o.calledOnce
+      o.restore()
+      


### PR DESCRIPTION
This MR adds the ability to conditionally respond to an API call in a way other than by passing `Prefer` headers. In practice, it enables a developer to use examples described in an API blueprint to create a feature-rich, scenario-based API mock.

Each request is now conditionally checked for the following:
* If a `Body` is present, this `Body` is compared with the request body (this also takes into account JSON, if headers are set to the right `content-type`)
* If a `Header` is present, this is compared with the request header

If a `Request` matches both `Body` and `Header`, api-mock returns the associated response.

If nothing matched, by specification, api-mock returns the last defined response.

If a `Prefer` header is passed, it is taken into account as usual and the behaviour remains unchanged.

Unit-tests are updated to reflect this, with a coverage of 100%.