### PR TITLE
Allow for custom Access-Control-Allow-Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # API-Mock 
 
+[![Build Status](https://travis-ci.org/localmed/api-mock.png?branch=master)](https://travis-ci.org/localmed/api-mock)
+[![Coverage Status](https://img.shields.io/coveralls/localmed/api-mock.svg)](https://coveralls.io/r/localmed/api-mock?branch=master)
+
 [![NPM](https://nodei.co/npm/api-mock.png?downloads=true)](https://nodei.co/npm/api-mock/)
 
 API-Mock is a [node.js](http://nodejs.org/) [npm](https://npmjs.org/) module that generates a mock server (express) from your API specification. Document your API in the [API blueprint](http://apiblueprint.org/) format, and API-Mock mocks your routes and sends the responses defined in the api spec.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-mock",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A mock server generated from your API Blueprint.",
   "author": "Evan Cordell <cordell.evan@gmail.com>",
   "main": "lib/api-mock.js",

--- a/src/api-mock.coffee
+++ b/src/api-mock.coffee
@@ -28,7 +28,10 @@ class ApiMock
       )
 
     if !@configuration.options['cors-disable']
-      corsSupport = new CorsSupport @app
+      corsSupport = new CorsSupport(
+        @app,
+            headers: @configuration.options['custom-headers']
+      )
 
   run: () ->
     app = @app

--- a/src/cors-support.coffee
+++ b/src/cors-support.coffee
@@ -1,12 +1,15 @@
 winston = require 'winston'
 
 class CorsSupport
-  constructor: (app) ->
+  constructor: (app, configuration) ->
 
     options =
       origin: '*'
       methods: 'GET, PUT, POST, PATCH, DELETE, TRACE, OPTIONS'
       headers: 'Origin, X-Requested-With, Content-Type, Accept, Authorization, Referer, Prefer'
+
+    if configuration.headers
+      options.headers = options.headers + ', ' + configuration.headers
 
     app.all '*', (req, res, next) ->
       unless req.get('Origin')

--- a/test/unit/api-mock-test.coffee
+++ b/test/unit/api-mock-test.coffee
@@ -73,6 +73,21 @@ describe 'ApiMock class', () ->
           assert.ok api_mock.configuration.options.port == 3005
           assert.notOk CorsSupportStub.called
 
+      describe 'with custom Access-Control-Allow-Headers', () ->
+
+        beforeEach ()->
+          configuration =
+            blueprintPath: './test/fixtures/single-get.apib',
+            options:
+              port: 3005
+              'custom-headers': 'x-custom-header'
+              'cors-disable': false
+
+        it 'should add custom header to configuration', () ->
+          api_mock = new ApiMock(configuration)
+          assert.ok api_mock.configuration.options['custom-headers'] == 'x-custom-header'
+          assert.ok CorsSupportStub.called
+
     describe 'with invalid configuration', () ->
 
       beforeEach ()->


### PR DESCRIPTION
This change allows for additional custom access-control headers to be set as options and allowed by the mock server.

Note that this pull request conflicts with pull request https://github.com/localmed/api-mock/pull/25