### PR TITLE
Update protagonist dependency to latest (v0.19.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prepublish": "scripts/prepublish"
   },
   "dependencies": {
-    "protagonist": "~0.12.0",
+    "protagonist": "~0.19.0",
     "optimist": "~0.6.0",
     "express": "~3.4.7",
     "uri-template": "~0.4.1",


### PR DESCRIPTION
First off, thanks for the great project.

Protagonist v0.12 was not building on node > v0.10.
This has been fixed in a [recent release of protagonist](https://github.com/apiaryio/protagonist/releases/tag/v0.19.0).

This PR updates the dependency. Unit tests are still passing, and `api-mock` now successfully installs in node 0.12.
