### PR TITLE
Update protagonist library to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prepublish": "scripts/prepublish"
   },
   "dependencies": {
-    "protagonist": "~1.2.5",
+    "protagonist": "~1.5.1",
     "optimist": "~0.6.0",
     "express": "~3.4.7",
     "uri-template": "~1.0.0",


### PR DESCRIPTION
Protagonist library starting supporting Node v5 and v6 in 1.3.2:
https://github.com/apiaryio/protagonist/releases/tag/v1.3.2

Without this, `api-mock` library fails to install when using these node versions.

Should fix #53 and actually a newer duplicate of #50 #52 